### PR TITLE
Fix deprecations

### DIFF
--- a/src/util/History.vala
+++ b/src/util/History.vala
@@ -42,7 +42,7 @@ public class ghistory.Util.History : GLib.Object {
                 Array<string> aResult = new Array<string> ();
                 command = lines[a];
                 aResult.append_val ((a+1).to_string());
-                if(command.size()>100){
+                if(command.length>100){
                     visible_command=command.substring(0,100)+" ...";
                 }else{
                     visible_command=command;

--- a/src/window/Window.vala
+++ b/src/window/Window.vala
@@ -179,7 +179,7 @@ public class ghistory.Window : ApplicationWindow {
                                    Column.INDEX, out an_index,
                                    Column.CONTENT, out a_content,
                                    Column.VISIBLE_CONTENT, out a_visible_content);
-            if(a_visible_content.len()!=0){
+            if(a_visible_content.length!=0){
                 copied=an_index;
 			    label.set_text ("\n Double-click to copy : " + a_visible_content );
             }else{
@@ -190,7 +190,7 @@ public class ghistory.Window : ApplicationWindow {
 	}
 
     void row_activated () {
-        if(copied!=null && copied.len()==an_index.len() && copied.contains(an_index)){
+        if(copied!=null && copied.length==an_index.length && copied.contains(an_index)){
             clipboard.set_text(a_content,-1);
             close();
         }


### PR DESCRIPTION
There were some deprecation that I fixed in this PR.

```
../src/util/History.vala:45.20-45.31: warning: string.size is deprecated. Use string.length
../src/window/Window.vala:182.16-182.36: warning: string.len is deprecated. Use string.length
../src/window/Window.vala:193.28-193.37: warning: string.len is deprecated. Use string.length
../src/window/Window.vala:193.42-193.53: warning: string.len is deprecated. Use string.length
```